### PR TITLE
[Refactor] Button size CSS 리팩토링

### DIFF
--- a/src/components/Button/Button/Button.module.scss
+++ b/src/components/Button/Button/Button.module.scss
@@ -124,28 +124,28 @@
     color: $color-white;
     cursor: not-allowed;
   }
+}
 
-  .free {
-    width: auto;
-  }
+.free {
+  width: auto;
+}
 
-  .sm {
-    width: 92px;
-  }
+.sm {
+  width: 92px;
+}
 
-  .md {
-    width: 280px;
-  }
+.md {
+  width: 280px;
+}
 
-  .lg {
-    width: 320px;
-  }
+.lg {
+  width: 320px;
+}
 
-  .xl {
-    width: 720px;
-  }
+.xl {
+  width: 720px;
+}
 
-  .full {
-    width: 100%;
-  }
+.full {
+  width: 100%;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #77 

## 📝작업 내용

반응형에 따라 버튼의 크기가 조절되는 경우 className으로 width 값을 변경할 수 있게 수정했습니다.
기존의 방식(&.[size])은 명시도가 `class 선택자`보다 높기 때문에 className으로 width값을 주어도 적용되지 않았습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

불편을 드려서 죄송합니다.
